### PR TITLE
Rename manifest.js to runtime.js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,7 +24,7 @@ module.exports = {
 
     optimization: {
         runtimeChunk: {
-            name: "manifest"
+            name: "runtime"
         }
     },
 


### PR DESCRIPTION
By default, workbox-webpack-plugin excludes /^manifest.*\.js(?:on)?$/

Renaming the runtimeChunk to "runtime.js" would include it in the precache-manifest.

Closes #6 